### PR TITLE
feat: custom override alias types

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -430,6 +430,17 @@ func (ts *Typescript) parse(obj types.Object) error {
 	switch obj := obj.(type) {
 	// All named types are type declarations
 	case *types.TypeName:
+		// Check for any custom overrides before processing any named types.
+		if custom, ok := ts.parsed.typeOverrides[obj.Type().String()]; ok {
+			return ts.setNode(objectIdentifier.Ref(), typescriptNode{
+				Node: &bindings.Alias{
+					Name:   objectIdentifier,
+					Type:   custom(),
+					Source: ts.location(obj),
+				},
+			})
+		}
+
 		var rhs types.Type
 		switch typedObj := obj.Type().(type) {
 		case *types.Named:

--- a/convert_test.go
+++ b/convert_test.go
@@ -90,6 +90,11 @@ func TestGeneration(t *testing.T) {
 			case "testdata/excludecustom":
 				err = gen.ExcludeCustom("github.com/coder/guts/testdata/excludecustom.Secret")
 				require.NoErrorf(t, err, "exclude %q", dir)
+			case "testdata/alias":
+				err = gen.IncludeCustom(map[guts.GolangType]guts.GolangType{
+					"github.com/coder/guts/testdata/alias.RemappedAlias": "string",
+				})
+				require.NoError(t, err)
 			}
 
 			gen.IncludeCustomDeclaration(config.StandardMappings())

--- a/testdata/alias/alias.go
+++ b/testdata/alias/alias.go
@@ -15,3 +15,6 @@ type AliasStruct = FooStruct
 type AliasStructNested = AliasStruct
 type AliasStructSlice = []FooStruct
 type AliasStructNestedSlice = []AliasStructNested
+
+// RemappedAlias should be manually remapped to "string" in the test settings.
+type RemappedAlias = FooStruct

--- a/testdata/alias/alias.ts
+++ b/testdata/alias/alias.ts
@@ -35,3 +35,6 @@ export type Foo = string;
 export interface FooStruct {
     readonly Key: string;
 }
+
+// From alias/alias.go
+export type RemappedAlias = string;


### PR DESCRIPTION
# Example


## Source

```golang
type FooStruct struct {
	Key string
}


// RemappedAlias should be manually remapped to "string" in the test settings.
type RemappedAlias = FooStruct
```

## Config

```golang
err = gen.IncludeCustom(map[guts.GolangType]guts.GolangType{
  "github.com/coder/guts/testdata/alias.RemappedAlias": "string",
})
```

## Output

```typescript
// From alias/alias.go
export type RemappedAlias = string;
```