### PR TITLE
fix: use custom type override in all usage

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -870,6 +870,14 @@ func (p parsedType) WithComments(comments ...string) parsedType {
 
 // TODO: Return comments?
 func (ts *Typescript) typescriptType(ty types.Type) (parsedType, error) {
+	// No matter what the type is, if we have some custom override, always use that.
+	custom, ok := ts.parsed.typeOverrides[ty.String()]
+	if ok {
+		return parsedType{
+			Value: custom(),
+		}, nil
+	}
+
 	switch ty := ty.(type) {
 	case *types.Signature:
 		// TODO: Handle functions better
@@ -1129,13 +1137,6 @@ func (ts *Typescript) typescriptType(ty types.Type) (parsedType, error) {
 			},
 		}, nil
 	case *types.Alias:
-		custom, ok := ts.parsed.typeOverrides[ty.String()]
-		if ok {
-			return parsedType{
-				Value: custom(),
-			}, nil
-		}
-
 		// See https://github.com/golang/go/issues/66559
 		// Rhs will traverse all aliasing types until it finds the base type.
 		return ts.typescriptType(ty.Rhs())

--- a/testdata/alias/alias.go
+++ b/testdata/alias/alias.go
@@ -19,6 +19,12 @@ type AliasStructNestedSlice = []AliasStructNested
 // RemappedAlias should be manually remapped to "string" in the test settings.
 type RemappedAlias = FooStruct
 
-type UseAliasedType struct {
-	Field1 RemappedAlias
+type UseAliasedType[G any] struct {
+	Field     RemappedAlias
+	AsKey     map[RemappedAlias]string
+	AsVal     map[string]RemappedAlias
+	AsSlice   []RemappedAlias
+	AsGeneric G
 }
+
+type GenericUseRemappedAlias = UseAliasedType[RemappedAlias]

--- a/testdata/alias/alias.ts
+++ b/testdata/alias/alias.ts
@@ -37,9 +37,22 @@ export interface FooStruct {
 }
 
 // From alias/alias.go
+export interface GenericUseRemappedAlias {
+    readonly Field: string;
+    readonly AsKey: Record<string, string> | null;
+    readonly AsVal: Record<string, string> | null;
+    readonly AsSlice: readonly string[];
+    readonly AsGeneric: string;
+}
+
+// From alias/alias.go
 export type RemappedAlias = string;
 
 // From alias/alias.go
-export interface UseAliasedType {
-    readonly Field1: string;
+export interface UseAliasedType<G extends any> {
+    readonly Field: string;
+    readonly AsKey: Record<string, string> | null;
+    readonly AsVal: Record<string, string> | null;
+    readonly AsSlice: readonly string[];
+    readonly AsGeneric: G;
 }


### PR DESCRIPTION
Custom type overrides was not working in some cases like Aliases, struct fields, etc. This change should make custom type overrides properly replace the overridden type.